### PR TITLE
Suggest a way to log.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ tonic = "0.5"
 prost = "0.8"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "0.8", default-features = false, features= ["v4"] }
+log = "0.4"
+env_logger = "0.9"
 
 [build-dependencies]
 tonic-build = "0.5"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	RUST_LOG=info,yorkie=debug cargo test -- --nocapture

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,13 +34,13 @@ impl Client {
         if self.is_active {
             return Ok(());
         }
-
         let mut client = YorkieClient::connect(self.rpc_address.clone()).await?;
         let request = tonic::Request::new(ActivateClientRequest {
             client_key: self.options.key.to_string(),
         });
         let response = client.activate_client(request).await?;
         let message = response.into_inner();
+        log::debug!("{} activated, id: {:?}", &self.options.key, &message.client_id);
         self.client_id = Some(message.client_id);
         self.is_active = true;
 
@@ -57,6 +57,7 @@ impl Client {
             client_id: self.client_id.clone().unwrap(),
         });
         client.deactivate_client(request).await?;
+        log::debug!("{} deactivated", &self.options.key);
         self.client_id = None;
         self.is_active = false;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod client_options;
 
 pub use client_options::*;
 pub use client::*;
+

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -2,9 +2,15 @@
 mod tests {
     use yorkie::{Client, ClientOptions};
 
+    fn init_logger() {
+        let _ = env_logger::builder()
+            .is_test(true)
+            .try_init();
+    }
 
     #[tokio::test]
     async fn client_with_new() {
+        init_logger();
         let mut cli = Client::new("http://[::1]:11101".to_string());
         assert_eq!(cli.is_active, false);
 
@@ -16,6 +22,7 @@ mod tests {
 
     #[tokio::test]
     async fn client_with_options_test() {
+        init_logger();
         let mut cli = Client::with_options("http://[::1]:11101".to_string(), ClientOptions {
             key: "test".to_string(),
             sync_loop_duration: 50,
@@ -31,6 +38,7 @@ mod tests {
 
     #[tokio::test]
     async fn client_deactivate_test() {
+        init_logger();
         let mut cli = Client::new("http://[::1]:11101".to_string());
         assert_eq!(cli.is_active, false);
 
@@ -44,3 +52,4 @@ mod tests {
         assert_eq!(cli.is_active, false);
     }
 }
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

### What this PR does / why we need it?
Suggest a way to log. This PR is more like a proposal. So I hope a better way can be freely discussed.

**1. Why was it written at the Debug level?**
I thought it would be appropriate to expose crate's logs at the debug level. The logs of the crates of `tokio` we are using are also exposed at the debug level, so I took this into account.

**2. init_logger() present in the test**
For `log` to work, the user needs to initialize an [implementation implementing the log facade](https://github.com/rust-lang/log#in-executables). `init_logger()` is a typical example of initializing an implementation to output a log in a test.

I think this will allow our users to initialize the log implementation they want and output the log in the format they want.

In addition, you can see that init_logger() is repeatedly called. It seems that Rust doesn't properly support the before setup hook. I'll try to refactor it to see if there is a better way.

**3. make test command**
This command runs the test so that only the debug level log of yorkie is output, not the debug level log of the crates we use.

### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #


### Any background context you want to provide?


### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

